### PR TITLE
Added fix for allowing move on square that's already taken

### DIFF
--- a/src/app/store/game/game.reducer.spec.ts
+++ b/src/app/store/game/game.reducer.spec.ts
@@ -56,4 +56,17 @@ describe('Game Reducer', () => {
     const state = gameReducer(initialState, endGame({ winner }));
     expect(state.winner).toEqual(winner);
   });
+
+  it('should not allow a move on an already taken square', () => {
+    const initialMove = makeMove({ position: 0 });
+    let state = gameReducer(initialState, initialMove);
+
+    // Attempt to make a move on the same position
+    const secondMove = makeMove({ position: 0 });
+    state = gameReducer(state, secondMove);
+
+    // The state should remain unchanged after the second move
+    expect(state.gameBoard[0].gamePiece).toBe('X');
+    expect(state.currentPlayer.piece).toBe('O');
+  });
 });

--- a/src/app/store/game/game.reducer.ts
+++ b/src/app/store/game/game.reducer.ts
@@ -47,6 +47,11 @@ export const gameReducer = createReducer(
     isDraw: false,
   })),
   on(makeMove, (state, { position }) => {
+    // If the square is already taken, do nothing
+    if (state.gameBoard[position].gamePiece !== '') {
+      return state;
+    }
+
     const newBoard = state.gameBoard.map((square, index) =>
       index === position
         ? { ...square, gamePiece: state.currentPlayer.piece }


### PR DESCRIPTION
This pull request includes changes to the `game.reducer` and its corresponding test file to handle the scenario where a move is attempted on an already taken square. The most important changes include adding a test case for this scenario and updating the reducer logic to prevent moves on occupied squares.

### Testing Enhancements:

* [`src/app/store/game/game.reducer.spec.ts`](diffhunk://#diff-27b1d6550918a0684428c8e4232674dc4a1319848b7e7acc4807f7826ce71af4R59-R71): Added a new test case to ensure that the game state does not change when a move is attempted on an already taken square.

### Reducer Logic Updates:

* [`src/app/store/game/game.reducer.ts`](diffhunk://#diff-07b4333eac244ded4e208f29a5cf25ce3417f28db068ffdbd635fa4f7618b388R50-R54): Updated the `makeMove` action handler to check if the square is already taken and, if so, return the current state without making any changes.