### PR TITLE
Fix for too many squares getting highlighted for wins

### DIFF
--- a/src/app/components/scoring/scoring.component.spec.ts
+++ b/src/app/components/scoring/scoring.component.spec.ts
@@ -104,7 +104,6 @@ describe('ScoringComponent', () => {
 
   it('should return true for isResult when there is a winner', () => {
     component.winner = initialState.game.player1;
-    console.log(component.isResult);
     expect(component.isResult).toBeTrue();
   });
 

--- a/src/app/store/game/game.reducer.spec.ts
+++ b/src/app/store/game/game.reducer.spec.ts
@@ -69,4 +69,23 @@ describe('Game Reducer', () => {
     expect(state.gameBoard[0].gamePiece).toBe('X');
     expect(state.currentPlayer.piece).toBe('O');
   });
+
+  it('should highlight only the squares that resulted in the win', () => {
+    const moves = [0, 1, 2, 3, 4, 5, 6];
+    let state: GameState = initialState;
+
+    moves.forEach((position) => {
+      state = gameReducer(state, makeMove({ position }));
+    });
+
+    expect(state.winner).toEqual(state.player1);
+    expect(state.player1.wins).toBe(1);
+    expect(state.gameBoard[0].isWinner).toBe(false);
+    expect(state.gameBoard[1].isWinner).toBe(false);
+    expect(state.gameBoard[2].isWinner).toBe(true);
+    expect(state.gameBoard[3].isWinner).toBe(false);
+    expect(state.gameBoard[4].isWinner).toBe(true);
+    expect(state.gameBoard[5].isWinner).toBe(false);
+    expect(state.gameBoard[6].isWinner).toBe(true);
+  });
 });

--- a/src/app/store/game/game.reducer.ts
+++ b/src/app/store/game/game.reducer.ts
@@ -58,7 +58,7 @@ export const gameReducer = createReducer(
         : square
     );
 
-    const winnerPiece = calculateWinner(newBoard);
+    const winningPositions = calculateWinner(newBoard);
 
     let winner = null;
     let player1 = { ...state.player1 };
@@ -66,8 +66,8 @@ export const gameReducer = createReducer(
     let isDraw = false;
     let draws = state.draws;
 
-    if (winnerPiece) {
-      if (winnerPiece === player1.piece) {
+    if (winningPositions) {
+      if (state.currentPlayer.piece === player1.piece) {
         player1 = { ...player1, wins: player1.wins + 1 };
         winner = player1;
       } else {
@@ -75,8 +75,9 @@ export const gameReducer = createReducer(
         winner = player2;
       }
 
+      // Highlight the squares that resulted in the win, not all for the winning player
       newBoard.forEach((square, index) => {
-        if (winnerPiece === square.gamePiece) {
+        if (winningPositions.includes(index)) {
           newBoard[index] = { ...square, isWinner: true };
         }
       });

--- a/src/app/utils/game-utils.ts
+++ b/src/app/utils/game-utils.ts
@@ -1,6 +1,7 @@
 import { Square } from '../models/square';
 
-export const calculateWinner = (gameBoard: Square[]): string | null => {
+// Calculate the winner and return the winning positions
+export const calculateWinner = (gameBoard: Square[]): number[] | null => {
   const winConditions = [
     [0, 1, 2],
     [3, 4, 5],
@@ -19,7 +20,7 @@ export const calculateWinner = (gameBoard: Square[]): string | null => {
       gameBoard[a].gamePiece === gameBoard[b].gamePiece &&
       gameBoard[a].gamePiece === gameBoard[c].gamePiece
     ) {
-      return gameBoard[a].gamePiece;
+      return [a, b, c];
     }
   }
   return null;


### PR DESCRIPTION
This pull request includes several changes to the game logic and tests to improve the handling of winning conditions and remove unnecessary logging. The most important changes include modifying the `calculateWinner` function to return winning positions, updating the game reducer to highlight only the winning squares, and adding a new test to verify this behavior.

### Game Logic Improvements:

* [`src/app/utils/game-utils.ts`](diffhunk://#diff-31d21a96e80217b56e3b2f2629c59a7893ca96ca8328aa7696ec4bad60c79059L3-R4): Modified the `calculateWinner` function to return the positions of the winning squares instead of the winning piece. [[1]](diffhunk://#diff-31d21a96e80217b56e3b2f2629c59a7893ca96ca8328aa7696ec4bad60c79059L3-R4) [[2]](diffhunk://#diff-31d21a96e80217b56e3b2f2629c59a7893ca96ca8328aa7696ec4bad60c79059L22-R23)
* [`src/app/store/game/game.reducer.ts`](diffhunk://#diff-07b4333eac244ded4e208f29a5cf25ce3417f28db068ffdbd635fa4f7618b388L61-R80): Updated the game reducer to use the new return value from `calculateWinner` and highlight only the squares that resulted in the win.

### Testing Enhancements:

* [`src/app/store/game/game.reducer.spec.ts`](diffhunk://#diff-27b1d6550918a0684428c8e4232674dc4a1319848b7e7acc4807f7826ce71af4R72-R90): Added a new test to verify that only the winning squares are highlighted.
* [`src/app/components/scoring/scoring.component.spec.ts`](diffhunk://#diff-6d0b3e44c3c9e8e37330362dedfb715adc77e85d0f45aafd85400407a14f1dc1L107): Removed an unnecessary console log statement from an existing test.