### PR TITLE
Update base styling to disable tap highlight 

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,9 +2,16 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 
 * {
+  // base styling
   margin: 0;
   padding: 0;
   font-family: "Inter";
+
+  /* Disable the highlight effect on tap */
+  -webkit-tap-highlight-color: transparent; /* For Safari and iOS */
+  -webkit-touch-callout: none; /* Prevents callout on long press */
+  -webkit-user-select: none; /* Prevents text selection on tap */
+  user-select: none; /* General selection disabling */
 }
 
 @keyframes blink {


### PR DESCRIPTION
This pull request includes a small update to the `src/styles.scss` file to improve user experience on touch devices by disabling certain default interactions.

Styling improvements:

* [`src/styles.scss`](diffhunk://#diff-23fad3928bf3e71585eb4a6e3b2ff72dae02c3ed5a44d2f0deb1d49f0cb3b1a3R5-R14): Added styles to disable the highlight effect on tap, prevent callout on long press, and disable text selection on tap.