### PR TITLE
Disable background if in single player mode

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": "*.component.html",
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
+}

--- a/src/app/components/game-board/game-board.component.html
+++ b/src/app/components/game-board/game-board.component.html
@@ -8,8 +8,10 @@
     </div>
   </section>
   <section class="game-board-content" [ngClass]="{ draw: isDraw }">
-    @if (gameModeValue === '2p') {
-    <div class="game-board-grid">
+    <div
+      class="game-board-grid"
+      [ngClass]="{ 'coming-soon-disabled': showComingSoon }"
+    >
       @for (square of gameBoard$ | async; track $index){
       <t3-square
         class="game-board-square"
@@ -19,13 +21,15 @@
       ></t3-square>
       }
     </div>
-    } @else {
+    @if (showComingSoon) {
     <div class="coming-soon">
       <h1>coming soon</h1>
     </div>
     }
   </section>
+  @if (!showComingSoon) {
   <section class="scoring-container">
     <t3-scoring class="scoring-content"></t3-scoring>
   </section>
+  }
 </article>

--- a/src/app/components/game-board/game-board.component.scss
+++ b/src/app/components/game-board/game-board.component.scss
@@ -3,7 +3,7 @@
   display: grid;
   justify-content: center;
   grid-template-columns:
-    1fr min(32rem, calc(100% - var(--viewport-padding) * 2))
+    1fr min(25rem, calc(100% - var(--viewport-padding) * 2))
     1fr;
   grid-template-areas:
     ". game-mode ."
@@ -40,6 +40,12 @@
     opacity: 1;
   }
 }
+
+.coming-soon-disabled {
+  opacity: 0.1;
+  pointer-events: none;
+}
+
 .coming-soon {
   position: absolute;
   left: 50%;

--- a/src/app/components/game-board/game-board.component.ts
+++ b/src/app/components/game-board/game-board.component.ts
@@ -59,6 +59,11 @@ export class GameBoardComponent implements OnInit {
       : 'Single Player';
   }
 
+  get showComingSoon() {
+    console.log(this.gameMode === GameModeEnum.SinglePlayer);
+    return this.gameMode === GameModeEnum.SinglePlayer;
+  }
+
   // Start the game when the component is initialized
   ngOnInit(): void {
     this.outcome$.subscribe((outcome) => {


### PR DESCRIPTION
This pull request includes several updates to the `game-board` component, focusing on adding a "coming soon" feature for the single-player mode, updating the styles, and configuring Prettier for consistent code formatting.

### Feature Enhancements:

* [`src/app/components/game-board/game-board.component.html`](diffhunk://#diff-8b3b26ca819df35bd862488c5c82eed0ecf7390517f626cd90d18a5eaefcef11L11-R14): Added conditional rendering to display a "coming soon" message when the single-player mode is selected and to disable the game board grid. [[1]](diffhunk://#diff-8b3b26ca819df35bd862488c5c82eed0ecf7390517f626cd90d18a5eaefcef11L11-R14) [[2]](diffhunk://#diff-8b3b26ca819df35bd862488c5c82eed0ecf7390517f626cd90d18a5eaefcef11L22-R34)
* [`src/app/components/game-board/game-board.component.ts`](diffhunk://#diff-afa869544747e63459232c81e65137b5fc0837e55c3917605f56f2da4fe60db9R62-R66): Introduced a `showComingSoon` getter to determine if the single-player mode is active and log the result.

### Style Updates:

* [`src/app/components/game-board/game-board.component.scss`](diffhunk://#diff-3df2551eee108ca3c3e9d47c1e39b54265a69903f8d76d66f68915db75cc9336L6-R6): Added styles for the `coming-soon-disabled` class to reduce opacity and disable pointer events. Adjusted the grid template columns for better layout. [[1]](diffhunk://#diff-3df2551eee108ca3c3e9d47c1e39b54265a69903f8d76d66f68915db75cc9336L6-R6) [[2]](diffhunk://#diff-3df2551eee108ca3c3e9d47c1e39b54265a69903f8d76d66f68915db75cc9336R43-R48)

### Configuration:

* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2R1-R10): Configured Prettier to enforce single quotes in HTML files with the `.component.html` extension.