### PR TITLE
Add delay to computer moves and refactor state mocks

### DIFF
--- a/src/app/store/game/game.reducer.ts
+++ b/src/app/store/game/game.reducer.ts
@@ -28,16 +28,12 @@ export const initialState: GameState = {
 
 export const gameReducer = createReducer(
   initialState,
-  on(startGame, (state, { gameMode }) => {
-    const newGameMode = gameMode;
-
-    return {
-      ...state,
-      gameBoard: Array(9).fill({ gamePiece: '', isWinner: false }),
-      outcome: OutcomeEnum.None,
-      gameMode: newGameMode,
-    };
-  }),
+  on(startGame, (state, { gameMode }) => ({
+    ...state,
+    gameBoard: Array(9).fill({ gamePiece: '', isWinner: false }),
+    outcome: OutcomeEnum.None,
+    gameMode: gameMode,
+  })),
   on(makeMove, (state, { position, currentPlayer }) => {
     let newBoard = state.gameBoard;
 

--- a/src/app/store/player/player.actions.ts
+++ b/src/app/store/player/player.actions.ts
@@ -1,7 +1,13 @@
-import { createAction } from '@ngrx/store';
+import { createAction, props } from '@ngrx/store';
+import { Player } from '../../models/player';
 
 export const resetPlayers = createAction('[Player] Reset Players');
 
 export const switchPlayer = createAction('[Player] Switch Player');
 
 export const updatePlayerWins = createAction('[Player] Update Player Wins');
+
+export const setCpuPlayer = createAction(
+  '[Player] Set CPU Player',
+  props<{ gamePiece: string }>()
+);

--- a/src/app/store/player/player.effects.spec.ts
+++ b/src/app/store/player/player.effects.spec.ts
@@ -1,121 +1,96 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Observable, of } from 'rxjs';
 import { PlayerEffects } from './player.effects';
-import { switchPlayer } from './player.actions';
+import { switchPlayer, setCpuPlayer } from './player.actions';
 import { makeMove } from '../game/game.actions';
-import { selectCurrentPlayer } from './player.selectors';
-import { PlayerState } from './player.reducer';
-import { Action } from '@ngrx/store';
-import { getInitialPlayerStateMock } from '../mocks/player-mocks';
-import { Player } from '../../models/player';
-import { selectGameMode } from '../game/game.selectors';
 import { GameModeEnum } from '../../enums/game-mode.enum';
+import { getInitialPlayerStateMock } from '../mocks/player-mocks';
+import { getInitialGameStateMock } from '../mocks/game-mocks';
+import { PlayerState } from './player.reducer';
+import { selectGameMode } from '../game/game.selectors';
+import { GameState } from '../game/game.reducer';
+import { selectCurrentPlayer } from './player.selectors';
 
 describe('PlayerEffects', () => {
-  let actions$: Observable<Action>;
+  let actions$: Observable<any>;
   let effects: PlayerEffects;
-  let storeMock: MockStore<{ player: PlayerState }>;
-  let initialPlayerStateMock: PlayerState;
-  let currentPlayerMock: Player;
+  let store: MockStore<{ game: GameState; player: PlayerState }>;
+
+  const initialPlayerState = getInitialPlayerStateMock();
+  const initialGameState = getInitialGameStateMock();
 
   beforeEach(() => {
-    initialPlayerStateMock = getInitialPlayerStateMock();
-
     TestBed.configureTestingModule({
       providers: [
         PlayerEffects,
         provideMockActions(() => actions$),
-        provideMockStore({ initialState: { player: initialPlayerStateMock } }),
+        provideMockStore({
+          initialState: {
+            player: initialPlayerState,
+            game: initialGameState,
+          },
+        }),
       ],
     });
 
     effects = TestBed.inject(PlayerEffects);
-    storeMock = TestBed.inject(MockStore);
-
-    initialPlayerStateMock = getInitialPlayerStateMock();
-    currentPlayerMock =
-      initialPlayerStateMock.players[initialPlayerStateMock.currentPlayerIndex];
-
-    storeMock.setState({ player: initialPlayerStateMock });
+    store = TestBed.inject(MockStore);
   });
 
   afterEach(() => {
-    storeMock.resetSelectors();
+    store.resetSelectors();
   });
 
-  it('should dispatch makeMove when gameMode is Single Player and currentPlayer is Player 2', (done) => {
-    const action = switchPlayer();
+  it('should dispatch makeMove action if current player is CPU in single player mode', (done) => {
+    const cpuCurrentPlayer = {
+      ...initialPlayerState.players[1],
+      isCpu: true,
+    };
 
-    // todo: maybe think about how to better use current player logic here
-    // todo: initialPlayerStateMock.player[1] or actually mock it out?
-    const outcome = makeMove({
-      currentPlayer: initialPlayerStateMock.players[1],
-    });
+    // Dispatch the setCpuPlayer action to update the state
+    store.dispatch(setCpuPlayer({ gamePiece: 'O' }));
 
-    actions$ = of(action);
+    // Override the selectors used in the effect
+    store.overrideSelector(selectGameMode, GameModeEnum.SinglePlayer);
+    store.overrideSelector(selectCurrentPlayer, cpuCurrentPlayer);
+    actions$ = of(switchPlayer());
 
-    storeMock.overrideSelector(
-      selectCurrentPlayer,
-      initialPlayerStateMock.players[1]
-    );
-
-    storeMock.overrideSelector(selectGameMode, GameModeEnum.SinglePlayer);
-
-    effects.switchPlayer$.subscribe((result) => {
-      expect(result).toEqual(outcome);
+    effects.switchPlayer$.subscribe((action) => {
+      expect(action).toEqual(
+        makeMove({
+          currentPlayer: cpuCurrentPlayer,
+        })
+      );
       done();
     });
   });
 
-  it('should dispatch NO_OP when gameMode is Single Player and currentPlayer is not Player 2', (done) => {
-    const action = switchPlayer();
-    const outcome = { type: 'NO_OP' };
+  it('should dispatch NO_OP action if current player is not CPU', (done) => {
+    const humanCurrentPlayer = {
+      ...initialPlayerState.players[0],
+      isCpu: false,
+    };
 
-    actions$ = of(action);
+    // Override the selectors used in the effect
+    store.overrideSelector(selectCurrentPlayer, humanCurrentPlayer);
+    actions$ = of(switchPlayer());
 
-    storeMock.overrideSelector(selectGameMode, GameModeEnum.SinglePlayer);
-
-    effects.switchPlayer$.subscribe((result) => {
-      expect(result).toEqual(outcome);
+    effects.switchPlayer$.subscribe((action) => {
+      expect(action).toEqual({ type: 'NO_OP' });
       done();
     });
   });
 
-  it('should dispatch NO_OP when gameMode is not Single Player', (done) => {
-    const action = switchPlayer();
-    const outcome = { type: 'NO_OP' };
+  it('should dispatch NO_OP action if game mode is not single player', (done) => {
+    store.overrideSelector(selectGameMode, GameModeEnum.TwoPlayer);
 
-    actions$ = of(action);
-    storeMock.overrideSelector(selectGameMode, GameModeEnum.TwoPlayer);
+    actions$ = of(switchPlayer());
 
-    effects.switchPlayer$.subscribe((result) => {
-      expect(result).toEqual(outcome);
+    effects.switchPlayer$.subscribe((action) => {
+      expect(action).toEqual({ type: 'NO_OP' });
       done();
     });
   });
-
-  // ! Ignoring this test for now
-  // xit('should handle multiple switchPlayer actions correctly', (done) => {
-  //   const action1 = switchPlayer();
-  //   const action2 = switchPlayer();
-  //   const currentPlayer1 = initialState.player.players[0];
-  //   const currentPlayer2 = initialState.player.players[1];
-  //   const outcome1 = { type: 'NO_OP' };
-  //   const outcome2 = simulateMove({ currentPlayer: currentPlayer2 });
-
-  //   actions$ = of(action1, action2);
-  //   storeMock.overrideSelector(selectCurrentPlayer, currentPlayer1);
-
-  //   effects.switchPlayer$.subscribe((result) => {
-  //     expect(result).toEqual(outcome1);
-  //     storeMock.overrideSelector(selectCurrentPlayer, currentPlayer2);
-
-  //     effects.switchPlayer$.subscribe((result2) => {
-  //       expect(result2).toEqual(outcome2);
-  //       done();
-  //     });
-  //   });
-  // });
 });

--- a/src/app/store/player/player.effects.ts
+++ b/src/app/store/player/player.effects.ts
@@ -25,10 +25,7 @@ export class PlayerEffects {
         this.store.select(selectGameMode)
       ),
       switchMap(([_, currentPlayer, gameMode]) => {
-        if (
-          gameMode === GameModeEnum.SinglePlayer &&
-          currentPlayer.name === 'Player 2'
-        ) {
+        if (gameMode === GameModeEnum.SinglePlayer && currentPlayer.isCpu) {
           return of(makeMove({ currentPlayer: currentPlayer }));
         } else {
           return of({ type: 'NO_OP' });

--- a/src/app/store/player/player.effects.ts
+++ b/src/app/store/player/player.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { of, switchMap, withLatestFrom } from 'rxjs';
+import { delay, of, pipe, switchMap, withLatestFrom } from 'rxjs';
 import { selectCurrentPlayer } from './player.selectors';
 import { makeMove } from '../game/game.actions';
 import { Store } from '@ngrx/store';
@@ -26,7 +26,9 @@ export class PlayerEffects {
       ),
       switchMap(([_, currentPlayer, gameMode]) => {
         if (gameMode === GameModeEnum.SinglePlayer && currentPlayer.isCpu) {
-          return of(makeMove({ currentPlayer: currentPlayer }));
+          return of(makeMove({ currentPlayer: currentPlayer })).pipe(
+            delay(500)
+          );
         } else {
           return of({ type: 'NO_OP' });
         }

--- a/src/app/store/player/player.reducer.spec.ts
+++ b/src/app/store/player/player.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { resetPlayers, switchPlayer } from './player.actions';
+import { resetPlayers, setCpuPlayer, switchPlayer } from './player.actions';
 import { playerReducer, PlayerState } from './player.reducer';
 import { updatePlayerWins } from './player.actions';
 import { getInitialPlayerStateMock } from '../mocks/player-mocks';
@@ -55,5 +55,15 @@ describe('Player Reducer', () => {
       updatePlayerWins()
     );
     expect(state.players[0].wins).toBe(0);
+  });
+
+  it('should handle setCpuPlayer action', () => {
+    const cpuPlayer = initialPlayerStateMock.players[1];
+
+    const state = playerReducer(
+      initialPlayerStateMock,
+      setCpuPlayer({ gamePiece: cpuPlayer.piece })
+    );
+    expect(state.players[1].isCpu).toBe(true);
   });
 });

--- a/src/app/store/player/player.reducer.ts
+++ b/src/app/store/player/player.reducer.ts
@@ -1,6 +1,11 @@
 import { createReducer, on } from '@ngrx/store';
 import { Player } from '../../models/player';
-import { resetPlayers, switchPlayer, updatePlayerWins } from './player.actions';
+import {
+  resetPlayers,
+  setCpuPlayer,
+  switchPlayer,
+  updatePlayerWins,
+} from './player.actions';
 
 export const playerFeatureKey = 'player';
 
@@ -51,6 +56,16 @@ export const playerReducer = createReducer(
       index === state.currentPlayerIndex
         ? { ...player, wins: player.wins + 1 }
         : player
+    );
+
+    return {
+      ...state,
+      players: updatedPlayers,
+    };
+  }),
+  on(setCpuPlayer, (state, { gamePiece }) => {
+    const updatedPlayers = state.players.map((player) =>
+      player.piece === gamePiece ? { ...player, isCpu: true } : player
     );
 
     return {


### PR DESCRIPTION
This pull request enhances the game and player state management by adding support for a single-player mode where the CPU can make moves. It includes changes to the game and player effects, actions, reducers, and their corresponding tests.

### Enhancements to game and player state management:

#### Game state management:
* [`src/app/store/game/game.effects.ts`](diffhunk://#diff-3f3a136439eb852dc4686c712c06b1a1b20ef71009f09191faa2f86c7978bfc9R27-R43): Added `startGame` effect to handle game initialization based on the game mode. If the game mode is single-player, it dispatches `setCpuPlayer` action; otherwise, it dispatches a no-op action.
* [`src/app/store/game/game.reducer.ts`](diffhunk://#diff-07b4333eac244ded4e208f29a5cf25ce3417f28db068ffdbd635fa4f7618b388L31-R36): Simplified the `startGame` reducer to reset the game state and set the game mode.

#### Player state management:
* [`src/app/store/player/player.actions.ts`](diffhunk://#diff-105156db4c362fa92c99a8fb277c8f198077bee6b047ddfee32110861af5767fL1-R13): Added `setCpuPlayer` action to designate a player as the CPU.
* [`src/app/store/player/player.reducer.ts`](diffhunk://#diff-3e2d81c2399c72904742078972c4d5d374f523b67c8749f24b1fcf008c156138R61-R70): Updated the reducer to handle the `setCpuPlayer` action, marking the specified player as the CPU.

#### Testing enhancements:
* [`src/app/store/game/game.effects.spec.ts`](diffhunk://#diff-b9f2dc8ffbca805869a9be8ffeebe01832872bc01e5dc859a816f3cfd48f7d66R201-R226): Added tests for `startGame` effect to ensure correct actions are dispatched based on the game mode.
* [`src/app/store/player/player.effects.spec.ts`](diffhunk://#diff-f357bf85233b774a5cce666a651f775a2887db897263990de8a2019b29749c0fL3-L120): Added tests for `switchPlayer` effect to verify CPU player behavior in single-player mode.
* [`src/app/store/player/player.reducer.spec.ts`](diffhunk://#diff-8519200051f208304b674a7870335faecd5c9d2c749c92b80c71d484895fae35R59-R68): Added a test to ensure the `setCpuPlayer` action correctly updates the player state.