### PR TITLE
Moving game move logic from reducers to game service

### DIFF
--- a/src/app/components/game-board/game-board.component.spec.ts
+++ b/src/app/components/game-board/game-board.component.spec.ts
@@ -108,6 +108,8 @@ describe('GameBoardComponent', () => {
     );
   });
 
+  it('should not dispatch attemptMove action when a square is clicked that is already taken', () => {});
+
   it('should dispatch startGame and swtichPlayer actions when a square is clicked and the outcome is not None', () => {
     component.outcome = OutcomeEnum.Win;
 

--- a/src/app/components/game-board/game-board.component.spec.ts
+++ b/src/app/components/game-board/game-board.component.spec.ts
@@ -95,20 +95,43 @@ describe('GameBoardComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should dispatch attemptMove action when a square is clicked and there is no outcome', () => {
+  it('should dispatch makeHumanMove action when a square is clicked and there is no outcome', () => {
     component.outcome = OutcomeEnum.None;
 
     const squareDebugElement: DebugElement = fixture.debugElement.query(
       By.css('t3-square')
     );
+
     squareDebugElement.triggerEventHandler('click', null);
 
     expect(dispatchSpy).toHaveBeenCalledWith(
-      RoundActions.attemptMove({ position: 0 })
+      RoundActions.makeHumanMove({ position: 0 })
     );
   });
 
-  it('should not dispatch attemptMove action when a square is clicked that is already taken', () => {});
+  it('should not dispatch makeHumanMove action when a square is clicked that is already taken', () => {
+    // Mock a game board with first square already taken
+    const position = 0;
+    const squareTakenMock = Array(9).fill({ gamePiece: '', isWinner: false });
+
+    squareTakenMock[position].gamePiece = currentPlayerMock.piece;
+    component.outcome = OutcomeEnum.None;
+
+    // Override selector with mock game board
+    store.overrideSelector(selectGameBoard, squareTakenMock);
+
+    // todo: should I be selecting the game board somewhere else?
+    // Reinitialize component to pick up new selector value
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    // Attempt move on first square
+    component.squareClick(position);
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      RoundActions.makeHumanMove({ position: position })
+    );
+  });
 
   it('should dispatch startGame and swtichPlayer actions when a square is clicked and the outcome is not None', () => {
     component.outcome = OutcomeEnum.Win;

--- a/src/app/components/game-board/game-board.component.ts
+++ b/src/app/components/game-board/game-board.component.ts
@@ -43,6 +43,7 @@ export class GameBoardComponent implements OnInit {
   processingMove$: Observable<boolean>;
   gameDifficulty$: Observable<GameDifficultyEnum>;
 
+  gameBoard!: Square[];
   outcome!: OutcomeEnum;
   currentPlayer!: Player;
   gameMode!: GameModeEnum;
@@ -99,6 +100,10 @@ export class GameBoardComponent implements OnInit {
       this.gameDifficulty = gameDifficulty;
     });
 
+    this.gameBoard$.subscribe((gameBoard) => {
+      this.gameBoard = gameBoard;
+    });
+
     this.store.dispatch(startGame({ gameMode: this.gameMode }));
   }
 
@@ -115,14 +120,9 @@ export class GameBoardComponent implements OnInit {
   }
 
   attemptMove(position: number) {
-    this.gameBoard$.subscribe((gameBoard) => {
-      const square = gameBoard[position];
-
-      // If the square is already taken, do nothing
-      if (square.gamePiece !== '') {
-        return;
-      }
-    });
+    if (this.gameBoard[position].gamePiece !== '') {
+      return;
+    }
 
     this.store.dispatch(RoundActions.makeHumanMove({ position }));
   }

--- a/src/app/components/game-board/game-board.component.ts
+++ b/src/app/components/game-board/game-board.component.ts
@@ -62,10 +62,6 @@ export class GameBoardComponent implements OnInit {
     return this.outcome === OutcomeEnum.Draw;
   }
 
-  get moveDelay() {
-    return this.currentPlayer.isCpu ? 500 : 0;
-  }
-
   get gameModeButtonText() {
     return this.gameMode.valueOf();
   }

--- a/src/app/components/game-board/game-board.component.ts
+++ b/src/app/components/game-board/game-board.component.ts
@@ -61,6 +61,10 @@ export class GameBoardComponent implements OnInit {
     return this.outcome === OutcomeEnum.Draw;
   }
 
+  get moveDelay() {
+    return this.currentPlayer.isCpu ? 500 : 0;
+  }
+
   get gameModeButtonText() {
     return this.gameMode.valueOf();
   }
@@ -106,8 +110,21 @@ export class GameBoardComponent implements OnInit {
       this.store.dispatch(startGame({ gameMode: this.gameMode }));
       this.store.dispatch(switchPlayer());
     } else {
-      this.store.dispatch(RoundActions.attemptMove({ position }));
+      this.attemptMove(position);
     }
+  }
+
+  attemptMove(position: number) {
+    this.gameBoard$.subscribe((gameBoard) => {
+      const square = gameBoard[position];
+
+      // If the square is already taken, do nothing
+      if (square.gamePiece !== '') {
+        return;
+      }
+    });
+
+    this.store.dispatch(RoundActions.makeHumanMove({ position }));
   }
 
   gameModeClick() {

--- a/src/app/services/game.service.spec.ts
+++ b/src/app/services/game.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { GameService } from './game.service';
 import { Square } from '../models/square';
+import { OutcomeEnum } from '../enums/outcome.enum';
 
 describe('GameService', () => {
   let service: GameService;
@@ -17,14 +18,14 @@ describe('GameService', () => {
   it('should return null if there is no winner', () => {
     const gameBoard: Square[] = [
       { gamePiece: 'X', isWinner: false },
-      { gamePiece: 'O', isWinner: false },
-      { gamePiece: 'X', isWinner: false },
-      { gamePiece: 'X', isWinner: false },
-      { gamePiece: 'X', isWinner: false },
-      { gamePiece: 'O', isWinner: false },
-      { gamePiece: 'O', isWinner: false },
-      { gamePiece: 'X', isWinner: false },
-      { gamePiece: 'O', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
     ];
     expect(service.calculateWinner(gameBoard)).toBeNull();
   });
@@ -80,5 +81,61 @@ describe('GameService', () => {
       isWinner: false,
     });
     expect(service.calculateWinner(gameBoard)).toBeNull();
+  });
+
+  it('should return Draw outcome if the board is full and no winner', () => {
+    const gameBoard: Square[] = [
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+    ];
+    expect(service.determineOutcome(gameBoard)).toEqual(OutcomeEnum.Draw);
+  });
+
+  it('should return Win outcome for determineOutcome if there is a winner', () => {
+    const gameBoard: Square[] = [
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+    ];
+    expect(service.determineOutcome(gameBoard)).toEqual(OutcomeEnum.Win);
+  });
+
+  it('should return None outcome if the board is not full and no winner', () => {
+    const gameBoard: Square[] = [
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: 'X', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: 'O', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+      { gamePiece: '', isWinner: false },
+    ];
+    expect(service.determineOutcome(gameBoard)).toEqual(OutcomeEnum.None);
+  });
+
+  it('should return random index for a CPU move', () => {
+    const gameBoard: Square[] = Array(9).fill({
+      gamePiece: '',
+      isWinner: false,
+    });
+
+    const randomIndex = service.makeCpuMove(gameBoard);
+    expect(randomIndex).toBeGreaterThanOrEqual(0);
+    expect(randomIndex).toBeLessThanOrEqual(8);
   });
 });

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Square } from '../models/square';
+import { OutcomeEnum } from '../enums/outcome.enum';
 
 @Injectable({
   providedIn: 'root',
@@ -31,5 +32,30 @@ export class GameService {
       }
     }
     return null;
+  }
+
+  determineOutcome(gameBoard: Square[]): OutcomeEnum {
+    const winningPositions = this.calculateWinner(gameBoard);
+    let outcome: OutcomeEnum = OutcomeEnum.None;
+
+    if (winningPositions) {
+      outcome = OutcomeEnum.Win;
+    } else if (gameBoard.every((square) => square.gamePiece !== '')) {
+      outcome = OutcomeEnum.Draw;
+    }
+
+    return outcome;
+  }
+
+  makeCpuMove(gameBoard: Square[]): number {
+    const emptySquares: number[] = [];
+    gameBoard.forEach((square, index) => {
+      if (square.gamePiece === '') {
+        emptySquares.push(index);
+      }
+    });
+
+    const randomIndex = Math.floor(Math.random() * emptySquares.length);
+    return emptySquares[randomIndex];
   }
 }

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -5,6 +5,8 @@ import { OutcomeEnum } from '../enums/outcome.enum';
 @Injectable({
   providedIn: 'root',
 })
+
+// todo: rename GameService to RoundService
 export class GameService {
   constructor() {}
 

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -5,8 +5,6 @@ import { OutcomeEnum } from '../enums/outcome.enum';
 @Injectable({
   providedIn: 'root',
 })
-
-// todo: rename GameService to RoundService
 export class GameService {
   constructor() {}
 

--- a/src/app/store/player/player.effects.spec.ts
+++ b/src/app/store/player/player.effects.spec.ts
@@ -51,16 +51,12 @@ describe('PlayerEffects', () => {
       isCpu: true,
     };
 
-    // Dispatch the setCpuPlayer action to update the state
-    store.dispatch(setCpuPlayer({ gamePiece: 'O' }));
-
     // Override the selectors used in the effect
-    store.overrideSelector(selectGameMode, GameModeEnum.SinglePlayer);
     store.overrideSelector(selectCurrentPlayer, cpuCurrentPlayer);
     actions$ = of(switchPlayer());
 
     effects.switchPlayer$.subscribe((action) => {
-      expect(action).toEqual(RoundActions.attemptMove({}));
+      expect(action).toEqual(RoundActions.makeCPUMove());
       done();
     });
   });
@@ -73,17 +69,6 @@ describe('PlayerEffects', () => {
 
     // Override the selectors used in the effect
     store.overrideSelector(selectCurrentPlayer, humanCurrentPlayer);
-    actions$ = of(switchPlayer());
-
-    effects.switchPlayer$.subscribe((action) => {
-      expect(action).toEqual({ type: 'NO_OP' });
-      done();
-    });
-  });
-
-  it('should dispatch NO_OP action if game mode is not single player', (done) => {
-    store.overrideSelector(selectGameMode, GameModeEnum.TwoPlayer);
-
     actions$ = of(switchPlayer());
 
     effects.switchPlayer$.subscribe((action) => {

--- a/src/app/store/player/player.effects.ts
+++ b/src/app/store/player/player.effects.ts
@@ -26,7 +26,7 @@ export class PlayerEffects {
       ),
       switchMap(([_, currentPlayer, gameMode]) => {
         if (gameMode === GameModeEnum.SinglePlayer && currentPlayer.isCpu) {
-          return of(RoundActions.attemptMove({}));
+          return of(RoundActions.makeCPUMove());
         } else {
           return of({ type: 'NO_OP' });
         }

--- a/src/app/store/player/player.effects.ts
+++ b/src/app/store/player/player.effects.ts
@@ -1,13 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { delay, of, switchMap, withLatestFrom } from 'rxjs';
+import { of, switchMap, withLatestFrom } from 'rxjs';
 import { selectCurrentPlayer } from './player.selectors';
 import { Store } from '@ngrx/store';
 import { GameState } from '../game/game.reducer';
 import { PlayerState } from './player.reducer';
 import { switchPlayer } from './player.actions';
-import { selectGameMode } from '../game/game.selectors';
-import { GameModeEnum } from '../../enums/game-mode.enum';
 import { RoundActions } from '../round/round.actions';
 
 @Injectable()
@@ -20,12 +18,9 @@ export class PlayerEffects {
   switchPlayer$ = createEffect(() =>
     this.actions$.pipe(
       ofType(switchPlayer),
-      withLatestFrom(
-        this.store.select(selectCurrentPlayer),
-        this.store.select(selectGameMode)
-      ),
-      switchMap(([_, currentPlayer, gameMode]) => {
-        if (gameMode === GameModeEnum.SinglePlayer && currentPlayer.isCpu) {
+      withLatestFrom(this.store.select(selectCurrentPlayer)),
+      switchMap(([_, currentPlayer]) => {
+        if (currentPlayer.isCpu) {
           return of(RoundActions.makeCPUMove());
         } else {
           return of({ type: 'NO_OP' });

--- a/src/app/store/round/round.actions.ts
+++ b/src/app/store/round/round.actions.ts
@@ -3,6 +3,12 @@ import { OutcomeEnum } from '../../enums/outcome.enum';
 import { Player } from '../../models/player';
 import { GameDifficultyEnum } from '../../enums/game-difficulty.enum';
 
+// todo: create different action groups for different types of actions
+/*
+  command actions - triggers effect only - i.e. make cpu move
+  event actions with payload - triggers effect - i.e. attempt move
+  result actions - updates state in reducer - i.e. start round
+*/
 export const RoundActions = createActionGroup({
   source: 'Round',
   events: {
@@ -14,11 +20,8 @@ export const RoundActions = createActionGroup({
       winningPositions: number[] | null;
     }>(),
     'Set Processing Move': props<{ processingMove: boolean }>(),
-    'Attempt Move': props<{ position?: number }>(),
-    'Make Move': props<{
-      position?: number;
-      currentPlayer: Player;
-      gameDifficulty: GameDifficultyEnum;
-    }>(),
+    'Set Board Position': props<{ position: number; piece: string }>(),
+    'Make Human Move': props<{ position: number }>(),
+    'Make CPU Move': emptyProps(),
   },
 });

--- a/src/app/store/round/round.effects.spec.ts
+++ b/src/app/store/round/round.effects.spec.ts
@@ -90,21 +90,6 @@ describe('RoundEffects', () => {
     });
   });
 
-  it('should dispatch no-op action on attemptMove if the square is taken', () => {
-    const action = RoundActions.attemptMove({ position: 0 });
-
-    actions$ = of(action);
-
-    mockStore.overrideSelector(selectGameBoard, [
-      { gamePiece: 'X', isWinner: false },
-      ...Array(8).fill({ gamePiece: '', isWinner: false }),
-    ]);
-
-    effects.attemptMove$.subscribe((result) => {
-      expect(result).toEqual({ type: 'NO_OP' });
-    });
-  });
-
   it('should dispatch the makeMove action with a delay if the current player is the CPU', (done) => {
     const cpuPlayer = {
       ...currentPlayerMock,

--- a/src/app/store/round/round.effects.spec.ts
+++ b/src/app/store/round/round.effects.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { delay } from 'rxjs/operators';
 import { Observable, of, toArray } from 'rxjs';
 import { RoundEffects } from './round.effects';
 import { GameService } from '../../services/game.service';
@@ -16,9 +15,8 @@ import { RoundActions } from './round.actions';
 import { OutcomeEnum } from '../../enums/outcome.enum';
 import { switchPlayer, updatePlayerWins } from '../player/player.actions';
 import { updateDraws } from '../game/game.actions';
-import { selectGameBoard, selectOutcome } from './round.selectors';
+import { selectGameBoard } from './round.selectors';
 import { selectCurrentPlayer } from '../player/player.selectors';
-import { GameDifficultyEnum } from '../../enums/game-difficulty.enum';
 
 export function mockDelay<T>(
   duration: number

--- a/src/app/store/round/round.effects.ts
+++ b/src/app/store/round/round.effects.ts
@@ -12,7 +12,6 @@ import { GameService } from '../../services/game.service';
 import { updateDraws } from '../game/game.actions';
 import { RoundState } from './round.reducer';
 import { selectGameBoard } from './round.selectors';
-import { selectGameDifficulty } from '../game/game.selectors';
 
 @Injectable()
 export class RoundEffects {

--- a/src/app/store/round/round.reducer.spec.ts
+++ b/src/app/store/round/round.reducer.spec.ts
@@ -46,6 +46,7 @@ describe('Round Reducer', () => {
       initialRoundStateMock,
       RoundActions.endRound({ outcome: OutcomeEnum.Win, winningPositions })
     );
+
     expect(state.outcome).toEqual(OutcomeEnum.Win);
     expect(state.gameBoard[0].isWinner).toBe(true);
     expect(state.gameBoard[1].isWinner).toBe(true);
@@ -67,5 +68,16 @@ describe('Round Reducer', () => {
       RoundActions.setProcessingMove({ processingMove })
     );
     expect(state.processingMove).toBe(processingMove);
+  });
+
+  it('should set the board position', () => {
+    const position = 0;
+    const piece = currentPlayerMock.piece;
+    const state = roundReducer(
+      initialRoundStateMock,
+      RoundActions.setBoardPosition({ position, piece })
+    );
+
+    expect(state.gameBoard[0].gamePiece).toBe(piece);
   });
 });

--- a/src/app/store/round/round.reducer.spec.ts
+++ b/src/app/store/round/round.reducer.spec.ts
@@ -40,37 +40,6 @@ describe('Round Reducer', () => {
     expect(state.outcome).toEqual(OutcomeEnum.None);
   });
 
-  it('should handle makeMove action when position is provided', () => {
-    const position = 0;
-    const state = roundReducer(
-      initialRoundStateMock,
-      RoundActions.makeMove({
-        position,
-        currentPlayer: currentPlayerMock,
-        gameDifficulty: GameDifficultyEnum.Easy,
-      })
-    );
-
-    expect(state.gameBoard[position].gamePiece).toEqual(
-      currentPlayerMock.piece
-    );
-  });
-
-  it('should handle makeMove action when no position is provided', () => {
-    const state = roundReducer(
-      initialRoundStateMock,
-      RoundActions.makeMove({
-        currentPlayer: currentPlayerMock,
-        gameDifficulty: GameDifficultyEnum.Easy,
-      })
-    );
-
-    const emptySquares = state.gameBoard.filter(
-      (square) => square.gamePiece === ''
-    );
-    expect(emptySquares.length).toBe(8);
-  });
-
   it('should handle endRound action with a win', () => {
     const winningPositions = [0, 1, 2];
     const state = roundReducer(

--- a/src/app/store/round/round.reducer.ts
+++ b/src/app/store/round/round.reducer.ts
@@ -2,7 +2,6 @@ import { createReducer, on } from '@ngrx/store';
 import { RoundActions } from './round.actions';
 import { OutcomeEnum } from '../../enums/outcome.enum';
 import { Square } from '../../models/square';
-import { GameDifficultyEnum } from '../../enums/game-difficulty.enum';
 
 export const roundFeatureKey = 'round';
 
@@ -33,45 +32,16 @@ export const roundReducer = createReducer(
       processingMove,
     };
   }),
-  on(
-    RoundActions.makeMove,
-    (state, { position, currentPlayer, gameDifficulty }) => {
-      let newBoard = state.gameBoard;
+  on(RoundActions.setBoardPosition, (state, { position, piece }) => {
+    const newBoard = state.gameBoard.map((square, index) =>
+      index === position ? { ...square, gamePiece: piece } : square
+    );
 
-      // If no position is provided or game difficulty is easy, make a random move
-      if (
-        position === undefined &&
-        gameDifficulty === GameDifficultyEnum.Easy
-      ) {
-        const emptySquares: number[] = [];
-        state.gameBoard.forEach((square, index) => {
-          if (square.gamePiece === '') {
-            emptySquares.push(index);
-          }
-        });
-
-        const randomIndex = Math.floor(Math.random() * emptySquares.length);
-        const randomEmptySquareIndex = emptySquares[randomIndex];
-
-        newBoard = state.gameBoard.map((square, index) =>
-          index === randomEmptySquareIndex
-            ? { ...square, gamePiece: currentPlayer.piece }
-            : square
-        );
-      } else {
-        newBoard = state.gameBoard.map((square, index) =>
-          index === position
-            ? { ...square, gamePiece: currentPlayer.piece }
-            : square
-        );
-      }
-
-      return {
-        ...state,
-        gameBoard: newBoard,
-      };
-    }
-  ),
+    return {
+      ...state,
+      gameBoard: newBoard,
+    };
+  }),
   on(RoundActions.endRound, (state, { outcome, winningPositions }) => {
     let newBoard = state.gameBoard;
 


### PR DESCRIPTION
This pull request includes several changes to improve the game logic and testing for the `GameBoardComponent`, `GameService`, and related effects. The most important changes include renaming actions, adding new methods for determining game outcomes, and updating tests accordingly.

### Game Logic Improvements:
* [`src/app/components/game-board/game-board.component.ts`](diffhunk://#diff-afa869544747e63459232c81e65137b5fc0837e55c3917605f56f2da4fe60db9L109-R123): Added `attemptMove` method to handle move attempts and check if a square is already taken.
* [`src/app/services/game.service.ts`](diffhunk://#diff-c44888bf3582cbe9762cfdb6bb4f3f0c7b5f4cfe9e2cb3362e6a69df6ce6c005R36-R60): Added `determineOutcome` and `makeCpuMove` methods to handle game outcomes and CPU moves.

### Action and Effect Updates:
* [`src/app/store/round/round.actions.ts`](diffhunk://#diff-03fe93fb399b361cae161ddd662b88ad13d8bc9c0dc74352abfc8351c659976fL17-R25): Renamed actions for clarity, such as `Make Human Move` and `Make CPU Move`.
* [`src/app/store/player/player.effects.ts`](diffhunk://#diff-42cafc2554eb47a7a38640a817a5e06f6236df3345acdff910b83a50af6e3e1dL23-R24): Updated `switchPlayer effect to handle CPU moves without checking game mode.

### Test Enhancements:
* [`src/app/components/game-board/game-board.component.spec.ts`](diffhunk://#diff-c81641aee96213aaa6b20e6d42b247e5cb16fe419875f44ea9efc5521f941637L98-R132): Added tests to ensure actions are dispatched correctly based on game state.
* [`src/app/services/game.service.spec.ts`](diffhunk://#diff-5f6c0aacb3a81934b3ba60cf0e25206c8d71abc76f8c08ed23bbc763269285f2R85-R140): Added tests for new `determineOutcome` and `makeCpuMove` methods.
* [`src/app/store/round/round.effects.spec.ts`](diffhunk://#diff-547ae98a6fc040fd4a9448616c8dc436fa1ee598dd562b30b0f7eb21ca6bfa00L200-R202): Updated tests to match new action names and logic.