### PR TITLE
Reset the round starting player when resetting the game mode

### DIFF
--- a/src/app/components/game-board/game-board.component.spec.ts
+++ b/src/app/components/game-board/game-board.component.spec.ts
@@ -21,7 +21,7 @@ import {
   selectCurrentPlayer,
   selectPlayers,
 } from '../../store/player/player.selectors';
-import { resetPlayers, switchPlayer } from '../../store/player/player.actions';
+import { resetPlayers } from '../../store/player/player.actions';
 import { GameState } from '../../store/game/game.reducer';
 import { PlayerState } from '../../store/player/player.reducer';
 import { getInitialPlayerStateMock } from '../../store/mocks/player-mocks';
@@ -29,7 +29,6 @@ import { getInitialGameStateMock } from '../../store/mocks/game-mocks';
 import {
   selectGameBoard,
   selectOutcome,
-  selectRoundStartingPlayerIndex,
 } from '../../store/round/round.selectors';
 import { RoundState } from '../../store/round/round.reducer';
 import { getInitialRoundStateMock } from '../../store/mocks/round-mocks';
@@ -280,6 +279,9 @@ describe('GameBoardComponent', () => {
     it('should reset players and draw count when resetGame is called', () => {
       component.resetGame();
 
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        RoundActions.resetRoundStartingPlayerIndex()
+      );
       expect(dispatchSpy).toHaveBeenCalledWith(resetPlayers());
       expect(dispatchSpy).toHaveBeenCalledWith(resetDraws());
     });

--- a/src/app/components/game-board/game-board.component.ts
+++ b/src/app/components/game-board/game-board.component.ts
@@ -130,6 +130,7 @@ export class GameBoardComponent implements OnInit {
   }
 
   resetGame() {
+    this.store.dispatch(RoundActions.resetRoundStartingPlayerIndex());
     this.store.dispatch(resetPlayers());
     this.store.dispatch(resetDraws());
   }

--- a/src/app/store/round/round.actions.ts
+++ b/src/app/store/round/round.actions.ts
@@ -25,5 +25,6 @@ export const RoundActions = createActionGroup({
     'Make Human Move': props<{ position: number }>(),
     'Make CPU Move': emptyProps(),
     'Switch Round Starting Player Index': emptyProps(),
+    'Reset Round Starting Player Index': emptyProps(),
   },
 });

--- a/src/app/store/round/round.reducer.spec.ts
+++ b/src/app/store/round/round.reducer.spec.ts
@@ -81,12 +81,21 @@ describe('Round Reducer', () => {
     expect(state.gameBoard[0].gamePiece).toBe(piece);
   });
 
-  it('should swith the round starting player index', () => {
+  it('should switch the round starting player index', () => {
     const state = roundReducer(
       initialRoundStateMock,
       RoundActions.switchRoundStartingPlayerIndex()
     );
 
     expect(state.roundStartingPlayerIndex).toBe(1);
+  });
+
+  it('should reset the round starting player index to 0', () => {
+    const state = roundReducer(
+      initialRoundStateMock,
+      RoundActions.resetRoundStartingPlayerIndex()
+    );
+
+    expect(state.roundStartingPlayerIndex).toBe(0);
   });
 });

--- a/src/app/store/round/round.reducer.ts
+++ b/src/app/store/round/round.reducer.ts
@@ -71,5 +71,11 @@ export const roundReducer = createReducer(
       ...state,
       roundStartingPlayerIndex: nextroundStartingPlayerIndex,
     };
+  }),
+  on(RoundActions.resetRoundStartingPlayerIndex, (state) => {
+    return {
+      ...state,
+      roundStartingPlayerIndex: 0,
+    };
   })
 );


### PR DESCRIPTION
This pull request introduces a new feature to reset the round starting player index in the game board component. The most important changes include updates to the game board component, the round actions, and the round reducer to support this new feature.

### Game Board Component Updates:
* [`src/app/components/game-board/game-board.component.ts`](diffhunk://#diff-afa869544747e63459232c81e65137b5fc0837e55c3917605f56f2da4fe60db9R133): Added a dispatch call to `RoundActions.resetRoundStartingPlayerIndex()` in the `resetGame` method.
* [`src/app/components/game-board/game-board.component.spec.ts`](diffhunk://#diff-c81641aee96213aaa6b20e6d42b247e5cb16fe419875f44ea9efc5521f941637R282-R284): Updated the test for `resetGame` to include an expectation for `RoundActions.resetRoundStartingPlayerIndex()` dispatch.

### Round Actions:
* [`src/app/store/round/round.actions.ts`](diffhunk://#diff-03fe93fb399b361cae161ddd662b88ad13d8bc9c0dc74352abfc8351c659976fR28): Added a new action `resetRoundStartingPlayerIndex` to the `RoundActions` group.

### Round Reducer:
* [`src/app/store/round/round.reducer.ts`](diffhunk://#diff-d2b1b8d96fd3cd46753fb3866ed11c2994e365107c200f0111683bfea09b9a27R74-R79): Added a new case in the reducer to handle `resetRoundStartingPlayerIndex` and reset the `roundStartingPlayerIndex` to 0.
* [`src/app/store/round/round.reducer.spec.ts`](diffhunk://#diff-081307ca7046f4a6048eb216c2fe0c049a313f9675782cb23bf60f3b6acb02d5L84-R100): Added a new test to verify that `resetRoundStartingPlayerIndex` resets the `roundStartingPlayerIndex` to 0.